### PR TITLE
feat: add sourcemap support

### DIFF
--- a/src/transform.ts
+++ b/src/transform.ts
@@ -1,9 +1,9 @@
 import { runtimePublicPath } from './serverPlugin'
-import { Transform } from 'vite'
+import { Transform, resolveConfig } from 'vite'
 
 export const reactRefreshTransform: Transform = {
   test: (path) => /\.(t|j)sx?$/.test(path),
-  transform: (code, _, isBuild, path) => {
+  transform: async (code, _, isBuild, path) => {
     if (
       isBuild ||
       path.startsWith(`/@modules/`) ||
@@ -12,7 +12,13 @@ export const reactRefreshTransform: Transform = {
       // do not transform for production builds
       return code
     }
-    return transformReactCode(code, path)
+
+    const mode = isBuild ? 'production' : 'development'
+
+    const config = await resolveConfig(mode)
+    const sourcemap = mode == 'development' && (config?.sourcemap || false)
+
+    return transformReactCode(code, path, sourcemap)
   }
 }
 
@@ -20,9 +26,14 @@ export const reactRefreshTransform: Transform = {
  * Transform React code to inject hmr ability.
  * Help tools that generate react code (.e.g mdx) to support hmr.
  */
-export const transformReactCode = (code: string, path: string) => {
+export const transformReactCode = (
+  code: string,
+  path: string,
+  sourcemap: boolean
+) => {
   const result = require('@babel/core').transformSync(code, {
-    plugins: [require('react-refresh/babel')]
+    plugins: [require('react-refresh/babel')],
+    sourceMaps: sourcemap ? 'inline' : false
   })
 
   if (!/\$RefreshReg\$\(/.test(result.code)) {
@@ -30,35 +41,46 @@ export const transformReactCode = (code: string, path: string) => {
     return code
   }
 
-  return `
-import RefreshRuntime from "${runtimePublicPath}"
+  const header = `
+import RefreshRuntime from "${runtimePublicPath}";
 
-let prevRefreshReg
-let prevRefreshSig
+let prevRefreshReg;
+let prevRefreshSig;
 
 if (!window.__vite_plugin_react_preamble_installed__) {
   throw new Error(
     "vite-plugin-react can't detect preamble. Something is wrong. See https://github.com/vitejs/vite-plugin-react/pull/11#discussion_r430879201"
-  )
+  );
 }
 
 if (import.meta.hot) {
-  prevRefreshReg = window.$RefreshReg$
-  prevRefreshSig = window.$RefreshSig$
+  prevRefreshReg = window.$RefreshReg$;
+  prevRefreshSig = window.$RefreshSig$;
   window.$RefreshReg$ = (type, id) => {
     RefreshRuntime.register(type, ${JSON.stringify(path)} + " " + id)
-  }
-  window.$RefreshSig$ = RefreshRuntime.createSignatureFunctionForTransform
-}
-
-${result.code}
-
-if (import.meta.hot) {
-  window.$RefreshReg$ = prevRefreshReg
-  window.$RefreshSig$ = prevRefreshSig
-
-  import.meta.hot.accept()
-  RefreshRuntime.performReactRefresh()
+  };
+  window.$RefreshSig$ = RefreshRuntime.createSignatureFunctionForTransform;
 }
 `
+
+  const footer = `
+if (import.meta.hot) {
+  window.$RefreshReg$ = prevRefreshReg;
+  window.$RefreshSig$ = prevRefreshSig;
+
+  import.meta.hot.accept();
+  RefreshRuntime.performReactRefresh();
+}
+`
+
+  if (sourcemap) {
+    return (
+      header.replace(/[\n]+/gm, '') +
+      result.code +
+      '\n' +
+      footer.replace(/[\n]+/gm, '')
+    )
+  }
+
+  return `${header}${result.code}${footer}`
 }


### PR DESCRIPTION
- Get `sourcemap` configuration via `resolveConfig()`
- Set babel's sourcemaps property to "inline"
- Make `transformReactCode`'s header and footer code into one line

![image](https://user-images.githubusercontent.com/1294640/83364121-71109700-a3a7-11ea-8a91-7dd81036acd5.png)
![image](https://user-images.githubusercontent.com/1294640/83364129-808fe000-a3a7-11ea-8547-f348bce1912d.png)
