### PR TITLE
feat: support babel plugin config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,8 @@ import { resolver } from './resolver'
 import { reactRefreshServerPlugin } from './serverPlugin'
 import { reactRefreshTransform } from './transform'
 
-module.exports = {
+module.exports = ({ babelPlugins }: { babelPlugins: any[] }) => ({
   resolvers: [resolver],
   configureServer: reactRefreshServerPlugin,
-  transforms: [reactRefreshTransform]
-}
+  transforms: [reactRefreshTransform(babelPlugins)]
+})


### PR DESCRIPTION
Many people are already using the experimental syntax 'classProperties'. But current plugin throw error about it, because babel doesn't handle this syntax by default.

![image](https://user-images.githubusercontent.com/18747423/88677564-06b67180-d120-11ea-9210-8ed557257193.png)

With is PR, users can provide their babel plugins so that babel can handle any syntax they use. 

BREAKING CHANGE: this package now export a plugin config function