### PR TITLE
fix: resolve with absolute path

### DIFF
--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -1,15 +1,17 @@
 import { Resolver } from 'vite'
+import path from 'path'
 
 export const resolver: Resolver = {
   alias(id) {
-    const isProd = process.env.NODE_ENV === 'production'
-    if (id === 'react' || id === '@pika/react') {
-      return isProd ? '@pika/react' : '@pika/react/source.development.js'
-    }
-    if (id === 'react-dom' || id === '@pika/react-dom') {
-      return isProd
-        ? '@pika/react-dom'
-        : '@pika/react-dom/source.development.js'
+    if (/^(@pika\/)?react(-dom)?$/.test(id)) {
+      if (process.env.NODE_ENV !== 'production') {
+        id += '/source.development.js'
+      }
+      return path.join(
+        process.cwd(),
+        'node_modules',
+        id.replace(/^(@pika\/)?/, '@pika' + path.sep)
+      )
     }
   }
 }


### PR DESCRIPTION
This ensures the same `@pika/react` package is used by all modules, even modules that exist outside the project root (ie: when a package is linked using `yarn link` or similar).