### PR TITLE
fix: missing export in dist/index.d.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,12 @@
+import type { Plugin } from 'vite'
 import { resolver } from './resolver'
 import { reactRefreshServerPlugin } from './serverPlugin'
 import { reactRefreshTransform } from './transform'
 
-module.exports = {
+const plugin: Plugin = {
   resolvers: [resolver],
   configureServer: reactRefreshServerPlugin,
   transforms: [reactRefreshTransform]
 }
+
+export = plugin


### PR DESCRIPTION
This allows `vite.config.ts` modules with `esModuleInterop: true` to import this plugin like so:
```ts
import reactPlugin from 'vite-plugin-react'
```